### PR TITLE
automatically discover and apply plan concurrency limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ You must `export` your API key in your shell so it is available as an environmen
 export GE_API_KEY=ge-xxxxxxxxxxxxxxxx
 ```
 
-You can check that this can been set correctly with the `env` command in your shell.
+You can check that it's been set correctly with the `env` command.
 
 #### Batch CSV Geocoding
 
@@ -72,16 +72,6 @@ and capture the updated CSV on `stdout` as such:
 
 ```bash
 cat input.csv | ge batch csv /dev/stdin | xsv table
-```
-
-##### Configuring your rate limits
-
-Trial users have a rate-limit of 5 queries-per-second (which is the default).
-If you have a paid plan then you can raise the concurrency:
-
-```bash
-ge batch csv \
-  --concurrency 20
 ```
 
 ##### Debugging

--- a/bin/cmd/batch/csv.js
+++ b/bin/cmd/batch/csv.js
@@ -34,7 +34,12 @@ module.exports = {
     yargs.option('concurrency', {
       type: 'number',
       default: 5,
-      describe: 'Maximim queries per-second.'
+      describe: 'Maximum queries per-second.'
+    })
+    yargs.option('discovery', {
+      type: 'boolean',
+      default: true,
+      describe: 'Maximum concurrency will be applied based on your plan limits.'
     })
   },
   handler: (argv) => {
@@ -44,6 +49,7 @@ module.exports = {
         templates: generateTemplates(argv),
         endpoint: argv.endpoint,
         concurrency: argv.concurrency,
+        discovery: argv.discovery,
         verbose: argv.verbose
       }))
       .pipe(stream.csv.stringifier())


### PR DESCRIPTION
This PR removes the need to tune the `--concurrency` param for users on paid plans.
I felt like this was a rough-edge as it would require users to log in and find their limits and tune them correctly.

This PR leaves the `--concurrency` value at the default of 5 but then raises the concurrency based on the response headers of the first successful request.

It can optionally be disabled with `--discovery 0` which allows users to specify a value lower than the maximum using `--concurrency`, if desired.

With `--verbose` logging enabled you can see the effect:

```bash
discovered QPS: 20
updating concurrency: 20
```