### PR TITLE
set client version param

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -3,6 +3,7 @@ const http = require('http')
 const https = require('https')
 const axios = require('axios')
 const profile = require('./profile')
+const package = require('../package.json')
 
 // Create an HTTP client with defaults
 // https://github.com/axios/axios#request-config
@@ -10,5 +11,8 @@ module.exports = (options) => axios.create(_.defaults(options, {
   httpAgent: new http.Agent({ keepAlive: true }),
   httpsAgent: new https.Agent({ keepAlive: true }),
   baseURL: 'https://api.geocode.earth',
-  params: { api_key: profile().api_key.toString() }
+  params: {
+    client: _.compact(['ge', 'cli', _.get(package, 'version')]).join('-'),
+    api_key: profile().api_key.toString()
+  }
 }))


### PR DESCRIPTION
this PR sets the `?client=xxx` query string param in order to distinguish it's use from the [autocomplete-element](https://github.com/geocodeearth/autocomplete-element) and other tooling.

see: https://github.com/geocodeearth/autocomplete-element/blob/35cb22576be2dfb2761e74bb3fcc2b9f0b86d590/src/autocomplete/autocomplete.js#L43