### PR TITLE
add update-notifier

### DIFF
--- a/bin/middleware.js
+++ b/bin/middleware.js
@@ -1,4 +1,7 @@
+const _ = require('lodash')
 const PrettyError = require('pretty-error')
+const updateNotifier = require('update-notifier')
+const pkg = require('../package.json')
 
 /**
  * The uncaughtExceptionMiddleware registers a global
@@ -22,6 +25,20 @@ const uncaughtExceptionMiddleware = (argv) => {
   })
 }
 
+/**
+ * The updateNotifierMiddleware prompts the user to upgrade
+ * the package when a newer version is available.
+ *
+ * see: https://github.com/yeoman/update-notifier
+ */
+const updateNotifierMiddleware = (argv) => {
+  // skip update notifier unless running a version published to npm
+  if (_.get(pkg, 'version', '0.0.0-development') === '0.0.0-development') { return }
+
+  updateNotifier({ pkg }).notify()
+}
+
 module.exports = [
-  uncaughtExceptionMiddleware
+  uncaughtExceptionMiddleware,
+  updateNotifierMiddleware
 ]

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "lodash": "^4.17.21",
     "pretty-error": "^3.0.4",
     "through2-parallel": "^0.1.3",
+    "update-notifier": "^5.1.0",
     "yargs": "^17.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
this PR adds an update notifier as seen in the `npm` command which informs users when their version is out-of-date.
see: https://github.com/yeoman/update-notifier