### PR TITLE
record status/errors and make recovery easier

### DIFF
--- a/bin/cmd/batch/csv.js
+++ b/bin/cmd/batch/csv.js
@@ -51,6 +51,12 @@ module.exports = {
       default: true,
       describe: 'Maximum concurrency will be applied based on your plan limits.'
     })
+    yargs.option('force', {
+      alias: 'f',
+      type: 'boolean',
+      default: false,
+      describe: 'Force previously geocoded rows to be refreshed.'
+    })
   },
   handler: (argv) => {
     fs.createReadStream(argv.file)


### PR DESCRIPTION
this PR addresses some feedback regarding our current error handling:
- non-200 API responses result in an instant `exit(1)` which is jarring and unhelpful
- restarting the job after a failure incurs additional billing costs when re-geocoding the same rows
- the requirement to have all fields specified by a template (`-t`) flag as a non-empty cell can be frustrating

---

changes in this PR:

**add a new column named `ge:errors`**
the column contains a pipe-delimited list of any error messages returned by the API.

**add another new column named `ge:status`**
this column contains the HTTP status code of the response.

**skip any fields which have been previously geocoded**
allow re-geocoding a previous output file by automatically skipping any rows where `ge:status=200`.

**allow the user to force all rows to be re-geocoded regardless of whether they have `ge:status=200`**
by introducing a new CLI flag (`--force`) which overrides the behaviour mentioned above.

---

I feel like this is much nicer because errors are non-fatal and the user can use a file output from this command as the input to a subsequent execution and they will only incur financial costs for rows which haven't been successfully geocoded.

resolves https://github.com/geocodeearth/ge/issues/9