### PR TITLE
feat(batch-csv): enable force mode

### DIFF
--- a/bin/cmd/batch/csv.js
+++ b/bin/cmd/batch/csv.js
@@ -67,7 +67,8 @@ module.exports = {
         endpoint: argv.endpoint,
         concurrency: argv.concurrency,
         discovery: argv.discovery,
-        verbose: argv.verbose
+        verbose: argv.verbose,
+        force: argv.force
       }))
       .pipe(stream.csv.stringifier())
       .pipe(process.stdout)


### PR DESCRIPTION
Fixes an omission in https://github.com/geocodeearth/ge/pull/10 where the variable `$force` was not being passed down to the command correctly.

This effectively disabled the ability to use `--force` on the CLI despite it being documented.