### PR TITLE
print CSV batch summary statistics

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "homepage": "https://github.com/geocodeearth/ge#readme",
   "dependencies": {
     "axios": "^0.21.1",
+    "colors": "^1.4.0",
     "csv-parse": "^4.16.0",
     "csv-stringify": "^5.6.2",
     "lodash": "^4.17.21",


### PR DESCRIPTION
This PR adds the batch summary info requested in https://github.com/geocodeearth/ge/issues/14

<img width="572" alt="Screenshot 2022-06-06 at 22 50 53" src="https://user-images.githubusercontent.com/738069/172247228-e35a7aec-cd5d-452a-8907-13fb7b776ab2.png">

Additionally the output produced from erroneous rows is now silent by default but can be enabled with the `verbose` flag.

cc @burritojustice 

resolves https://github.com/geocodeearth/ge/issues/14