### PR TITLE
summary: clean up terminal artefacts

### DIFF
--- a/stream/batch.js
+++ b/stream/batch.js
@@ -14,6 +14,7 @@ const streamFactory = (options) => {
 
   // optionally repaint metrics after each log line
   function log () {
+    process.stderr.clearScreenDown()
     console.error.apply(null, arguments)
     if (options.summary && options.tick) { options.metrics.overprint() }
   }


### PR DESCRIPTION
when using tick mode in combination with verbose mode printing multiline strings

<img width="674" alt="Screenshot 2022-06-10 at 17 03 37" src="https://user-images.githubusercontent.com/738069/173094550-b15d8c2c-030b-432a-a5bc-25159dd6b0d0.png">

