### PR TITLE
Default to `size=1`

### DIFF
--- a/stream/batch.js
+++ b/stream/batch.js
@@ -63,6 +63,11 @@ const streamFactory = (options) => {
       return next(null, row)
     }
 
+    // always use size=1 for performance, unless overidden
+    if (!req.params.size) {
+      req.params.size = '1'
+    }
+
     // verbose logging
     if (options.verbose) { log(options.endpoint, req) }
 


### PR DESCRIPTION
For batch geocoding, only the first result is ever relevant, and there _is_ a small performance benefit, both on the server and client sides, to only sending back a single result. It saves a lot of parsing of JSON, bytes over the wire, etc.